### PR TITLE
fix(slack): include text in postMessage

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33281,11 +33281,12 @@ exports.parseRichTextElement = parseRichTextElement;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.postMessage = void 0;
 const web_api_1 = __nccwpck_require__(431);
-function postMessage(blocks, token, channelId) {
+function postMessage(title, blocks, token, channelId) {
     const client = new web_api_1.WebClient(token);
     return client.chat.postMessage({
         channel: channelId,
         blocks,
+        text: title,
     });
 }
 exports.postMessage = postMessage;
@@ -39612,7 +39613,7 @@ async function main() {
 async function postToSlack() {
     const changelogSnippet = result.join("\n").trim();
     const blocks = (0, default_1.parseChangelog)(changelogSnippet, title);
-    await (0, slack_1.postMessage)(blocks, slackToken, slackChannel);
+    await (0, slack_1.postMessage)(title, blocks, slackToken, slackChannel);
 }
 function evaluateLine(line) {
     if (line.startsWith(`## [${version}] -`)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ async function main() {
 async function postToSlack() {
   const changelogSnippet = result.join("\n").trim();
   const blocks = parseChangelog(changelogSnippet, title);
-  await postMessage(blocks, slackToken, slackChannel);
+  await postMessage(title, blocks, slackToken, slackChannel);
 }
 
 function evaluateLine(line: string) {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -1,10 +1,16 @@
 import { WebClient } from "@slack/web-api";
 import { Block } from "@slack/types";
 
-export function postMessage(blocks: Block[], token: string, channelId: string) {
+export function postMessage(
+  title: string,
+  blocks: Block[],
+  token: string,
+  channelId: string,
+) {
   const client = new WebClient(token);
   return client.chat.postMessage({
     channel: channelId,
     blocks,
+    text: title,
   });
 }


### PR DESCRIPTION
Resolves the following warning:

<img width="679" alt="image" src="https://github.com/alexfu/changelog-slack-notifier-action/assets/987398/6575e335-a2bc-45ca-b01f-d321c1db442d">
